### PR TITLE
fix: fallback to stdin automatically if no url provided by flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --url value    source url to parse [$URL_PARSER_URL]
-   --stdin        read url to parse from stdin (default: false) [$URL_PARSER_STDIN]
    --help, -h     show help
    --version, -v  print the version
 ```
@@ -78,6 +77,10 @@ some-key=somevalue
 
 $ url-parser --url https://somedomain.com/?some-key=somevalue query --query-field=some-key
 somevalue
+
+# It is also possible to read the URL from stdin
+$ echo "https://somedomain.com" | url-parser host
+somedomain.com
 ```
 
 ## Contributors

--- a/cmd/url-parser/main.go
+++ b/cmd/url-parser/main.go
@@ -37,12 +37,6 @@ func main() {
 				EnvVars:     []string{"URL_PARSER_URL"},
 				Destination: &cfg.URL,
 			},
-			&cli.BoolFlag{
-				Name:        "stdin",
-				Usage:       "read url to parse from stdin",
-				EnvVars:     []string{"URL_PARSER_STDIN"},
-				Destination: &cfg.Stdin,
-			},
 		},
 		Commands: []*cli.Command{
 			{
@@ -103,31 +97,19 @@ func main() {
 			},
 		},
 		Before: func(ctx *cli.Context) error {
-			if cfg.URL == "" && !cfg.Stdin {
-				_ = cli.ShowAppHelp(ctx)
-
-				return fmt.Errorf("error: %w", config.ErrRequiredFlagsNotSet)
-			}
-
-			if cfg.URL != "" && cfg.Stdin {
-				_ = cli.ShowAppHelp(ctx)
-
-				return fmt.Errorf("error: %w", config.ErrExclusiveFlags)
-			}
-
-			if cfg.Stdin {
+			if cfg.URL == "" {
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
 					stdin, err := io.ReadAll(os.Stdin)
 					if err != nil {
-						return fmt.Errorf("error: %w: %w", config.ErrEmptyStdin, err)
+						return fmt.Errorf("error: %w: %w", config.ErrReadStdin, err)
 					}
 					cfg.URL = strings.TrimSuffix(string(stdin), "\n")
 				}
+			}
 
-				if cfg.URL == "" {
-					return fmt.Errorf("error: %w", config.ErrEmptyStdin)
-				}
+			if cfg.URL == "" {
+				return fmt.Errorf("error: %w", config.ErrEmptyURL)
 			}
 
 			return nil

--- a/config/config.go
+++ b/config/config.go
@@ -3,11 +3,9 @@ package config
 import "errors"
 
 var (
-	ErrRequiredFlagsNotSet = errors.New("either \"url\" or \"stdin\" must be set")
-	ErrExclusiveFlags      = errors.New("\"url\" and \"stdin\" are mutually exclusive")
-	ErrEmptyStdin          = errors.New("\"stdin\" must not be empty")
-	ErrReadStdin           = errors.New("failed to read \"stdin\"")
-	ErrParseURL            = errors.New("failed to parse url")
+	ErrEmptyURL  = errors.New("no url provided either by \"url\" or \"stdin\"")
+	ErrReadStdin = errors.New("failed to read \"stdin\"")
+	ErrParseURL  = errors.New("failed to parse url")
 )
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,6 @@ var (
 
 type Config struct {
 	URL        string
-	Stdin      bool
 	QueryField string
 	PathIndex  int
 }


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/url-parser/issues/64