### PR TITLE
fix: rename host flag alias from h to ht

### DIFF
--- a/cmd/url-parser/main.go
+++ b/cmd/url-parser/main.go
@@ -72,7 +72,7 @@ func main() {
 			},
 			{
 				Name:    "host",
-				Aliases: []string{"h"},
+				Aliases: []string{"ht"},
 				Usage:   "Get hostname from url",
 				Action:  command.Host(cfg),
 			},


### PR DESCRIPTION
BREAKING CHANGE: The alias `h` for the `host` flag was in conflict with the default help alias and was renamed to `ht`.